### PR TITLE
reload when dbfile is updated

### DIFF
--- a/manifests/dbfile.pp
+++ b/manifests/dbfile.pp
@@ -51,7 +51,7 @@ define postfix::dbfile (
       cwd         => $postfixdir,
       subscribe   => File["${postfixdir}/${title}"],
       refreshonly => true,
-      # No need to notify the service, since it detects changed files
+      notify      => Service['postfix'],
     }
 
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,7 +41,7 @@ class postfix::params {
       $manpage_directory = '/usr/share/man'
       $readme_directory = '/usr/share/doc/postfix'
       $sample_directory = '/usr/share/doc/postfix/examples'
-      $service_restart = '/usr/sbin/service postfix check && /usr/sbin/service postfix restart'
+      $service_restart = '/usr/sbin/service postfix reload'
       $dovecot_directory = '/usr/lib/dovecot'
       $postfix_package = 'postfix'
       $postfix_mysql_package = 'postfix-mysql'


### PR DESCRIPTION
postfix will pick up changes automatically when the server is quiescent, but it never is on the MX-in hosts. this will reload the server config when spam maps are updated.

this patch also switches the debian restart command to a graceful reload. there is no need to do a hard restart.