### PR TITLE
Quote the variable so spaces etc can be detected

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -86,7 +86,7 @@ class postfix::params {
       $postmap = '/usr/local/sbin/postmap'
     }
     default: {
-      fail("Unsupported OS family '${::osfamily}'")
+      fail("Unsupported OS family '${osfamily}'")
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -86,7 +86,7 @@ class postfix::params {
       $postmap = '/usr/local/sbin/postmap'
     }
     default: {
-      fail("Unsupported OS family ${::osfamily}")
+      fail("Unsupported OS family '${::osfamily}'")
     }
   }
 }


### PR DESCRIPTION
It looks like the variable name may be blank or empty, note the spaces after family:

... Unsupported OS family  (file: ...

Add quotes to make it obvious what variable was set up

